### PR TITLE
:wrench: env: add .gitattributes to exclude HTML files from linguist detection

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.html linguist-detectable=false


### PR DESCRIPTION
This pull request includes a small change to the `.gitattributes` file. The change ensures that `.html` files are marked as non-detectable by Linguist for language statistics.