### PR TITLE
Refine README and enhance fortune messages in JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## NAME
 
-bytecookie - A variation of the Fortune command for engineers
+bytecookie - display engineer-themed fortune messages
 
 ## SYNOPSIS
 
@@ -10,22 +10,33 @@ bytecookie - A variation of the Fortune command for engineers
 
 ## DESCRIPTION
 
-`bytecookie` is a command-line tool that displays a random or daily "fortune" message for engineers, inspired by HTTP status codes, programming idioms, and error messages. Messages are designed to be motivational, humorous, or thought-provoking for developers.
+`bytecookie` displays random fortune messages for engineers, inspired by HTTP status codes, programming idioms, error messages, and developer culture.
 
-Messages are selected either randomly or deterministically based on the current date and an optional user name, ensuring a unique "fortune" for each user per day.
+When a username is specified, a deterministic message is selected based on the current date and username.
+
+Small bytes. Small bites. Small pieces of wisdom.
 
 ## OPTIONS
 
 - `-u`, `--user <USER>`
-  - Specify a user name to receive a daily fortune message. The same user will get the same message throughout the day.
+  - Specify a username to get the same message throughout the day.
 
 - `-j`, `--json <PATH>`
-  - Specify a custom JSON file containing fortune messages. If not provided, embedded messages are used.
+  - Load fortune messages from the specified JSON file. If not provided, embedded messages are used.
+
+- `-c`, `--color <WHEN>`
+  - Control colored output. Options are:
+    - `auto` (default): Enable color if output is a terminal.
+    - `always`: Always enable color.
+    - `never`: Never enable color.
 
 ## ENVIRONMENT
 
 - `BYTE_COOKIES_JSON`  
   Path to a custom message JSON file. Used if the `--json` option is not specified.
+
+- `NO_COLOR`  
+  If set, disables colored output. See [NO_COLOR](https://no-color.org/) for more details.
 
 ## EXAMPLES
 
@@ -39,10 +50,6 @@ bytecookie --user alice@example.com
 # Use a custom message file
 bytecookie --json ./mycookies.json
 ```
-
-## FILE
-
-- Custom message file (JSON format, see `assets/bytecookies.json` for example)
 
 ## SEE ALSO
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Small bytes. Small bites. Small pieces of wisdom.
   Path to a custom message JSON file. Used if the `--json` option is not specified.
 
 - `NO_COLOR`  
-  If set, disables colored output. See [NO_COLOR](https://no-color.org/) for more details.
+  If set, disables colored output unless overridden by command-line options. See [NO_COLOR](https://no-color.org/) for more details.
 
 ## EXAMPLES
 

--- a/assets/bytecookies.json
+++ b/assets/bytecookies.json
@@ -9,7 +9,7 @@
     },
     {
         "snippet": "201 Created",
-        "message": "Today is a good day to build something new."
+        "message": "Something new has entered the world. Handle with care."
     },
     {
         "snippet": "202 Accepted",
@@ -33,7 +33,7 @@
     },
     {
         "snippet": "304 Not Modified",
-        "message": "No need to change. You're already enough today."
+        "message": "No changes detected. Maybe that's okay."
     },
     {
         "snippet": "400 Bad Request",
@@ -41,15 +41,15 @@
     },
     {
         "snippet": "401 Unauthorized",
-        "message": "Believe in your worth - and don't forget your credentials."
+        "message": "Believe in yourself - but don't forget your credentials."
     },
     {
         "snippet": "402 Payment Required",
-        "message": "Sometimes you need to invest in yourself."
+        "message": "Not everything valuable is free."
     },
     {
         "snippet": "403 Forbidden",
-        "message": "Just because you can see it, doesn't mean it's yours today."
+        "message": "Just because you can see it doesn't mean it's yours today."
     },
     {
         "snippet": "404 Not Found",
@@ -57,11 +57,11 @@
     },
     {
         "snippet": "405 Method Not Allowed",
-        "message": "Sometimes you need to try a different approach."
+        "message": "The goal may be right. The method isn't."
     },
     {
         "snippet": "406 Not Acceptable",
-        "message": "Your standards are high, and that's okay."
+        "message": "Not every compromise is worth making."
     },
     {
         "snippet": "418 I'm a teapot",
@@ -85,10 +85,10 @@
     },
     {
         "snippet": "504 Gateway Timeout",
-        "message": "Some things just take longer. Patience is your ally."
+        "message": "Waiting is also a kind of process."
     },
     {
-        "snippet": "while(1) { doSomething(); }",
+        "snippet": "while (1) { doSomething(); }",
         "message": "Even an infinite loop deserves a break."
     },
     {
@@ -137,7 +137,7 @@
     },
     {
         "snippet": "bool success = false;",
-        "message": "Every false has the potential to flip."
+        "message": "Every false has the potential to become true."
     },
     {
         "snippet": "var result = null;",
@@ -169,7 +169,7 @@
     },
     {
         "snippet": "cat file | grep \"hope\"",
-        "message": "You'll always find what you're looking for - if you know how to search."
+        "message": "Sometimes the answer is already in the logs."
     },
     {
         "snippet": "exit 0",
@@ -192,12 +192,20 @@
         "message": "Some things are never truly finished."
     },
     {
+        "snippet": "<<<<<<< HEAD",
+        "message": "Some conflicts cannot be resolved automatically."
+    },
+    {
         "snippet": "NullPointerException",
         "message": "Maybe what you trusted... wasn't really there."
     },
     {
         "snippet": "syntax error near unexpected token",
         "message": "Even the smallest misstep can derail the best intentions."
+    },
+    {
+        "snippet": "warning: unused variable",
+        "message": "Not everything you carry is necessary."
     },
     {
         "snippet": "undefined reference to 'main'",
@@ -225,11 +233,11 @@
     },
     {
         "snippet": "OutOfMemoryError",
-        "message": "Sometimes, pushing past your limits leads to new inspiration."
+        "message": "Even the biggest dreams need more memory."
     },
     {
         "snippet": "panic: unexpected error",
-        "message": "Even the best of us lose control sometimes."
+        "message": "Even the strongest systems panic sometimes."
     },
     {
         "snippet": "fatal: not a git repository",
@@ -244,51 +252,51 @@
         "message": "Sometimes, a reset is all you really need."
     },
     {
-        "snippet": "EPERM(1) - Operation not permitted",
+        "snippet": "EPERM (errno 1): Operation not permitted",
         "message": "You might need to level up before proceeding."
     },
     {
-        "snippet": "ENOENT(2) - No such file or directory",
+        "snippet": "ENOENT (errno 2): No such file or directory",
         "message": "Sometimes, you just need to create your own path."
     },
     {
-        "snippet": "ESRCH(3) - No such process",
+        "snippet": "ESRCH (errno 3): No such process",
         "message": "Stop chasing ghosts."
     },
     {
-        "snippet": "EINTR(4) - Interrupted system call",
+        "snippet": "EINTR (errno 4): Interrupted system call",
         "message": "Sometimes, you just need to take a break."
     },
     {
-        "snippet": "EIO(5) - I/O error",
+        "snippet": "EIO (errno 5): I/O error",
         "message": "Not everything that fails is your fault."
     },
     {
-        "snippet": "ENXIO(6) - No such device or address",
+        "snippet": "ENXIO (errno 6): No such device or address",
         "message": "Maybe you're knocking on the wrong door."
     },
     {
-        "snippet": "E2BIG(7) - Argument list too long",
+        "snippet": "E2BIG (errno 7): Argument list too long",
         "message": "Keep it simple. Even the kernel thinks so."
     },
     {
-        "snippet": "EAGAIN(11) - Try again",
+        "snippet": "EAGAIN (errno 11): Try again",
         "message": "Patience is part of progress."
     },
     {
-        "snippet": "ENOMEM(12) - Out of memory",
+        "snippet": "ENOMEM (errno 12): Out of memory",
         "message": "You've been thinking too much. Time to rest."
     },
     {
-        "snippet": "EACCES(13) - Permission denied",
+        "snippet": "EACCES (errno 13): Permission denied",
         "message": "It's not always the right time - or the right key."
     },
     {
-        "snippet": "ENOSPC(28) - No space left on device",
+        "snippet": "ENOSPC (errno 28): No space left on device",
         "message": "You may need to let go before you can move on."
     },
     {
-        "snippet": "EINVAL(22) - Invalid argument",
+        "snippet": "EINVAL (errno 22): Invalid argument",
         "message": "What makes sense to you might not compute elsewhere."
     },
     {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,13 @@
-use clap::Parser;
+use clap::{Parser, ValueEnum};
 use std::io::Read;
+
+/// Color mode for output
+#[derive(Clone, Debug, ValueEnum)]
+enum ColorMode {
+    Auto,
+    Always,
+    Never,
+}
 
 /// Command line arguments
 #[derive(Debug, Parser)]
@@ -12,6 +20,10 @@ struct Args {
     /// Message JSON file path
     #[arg(short, long, env = "BYTE_COOKIES_JSON", hide_env_values = true, default_value = None)]
     json: Option<String>,
+
+    /// Color mode (auto, always, never)
+    #[arg(short, long, value_enum, default_value = "auto")]
+    color: ColorMode,
 }
 
 /// Structure for one message in the JSON
@@ -59,27 +71,46 @@ fn decide_todays_index(count: usize, today: &str, user: &str) -> usize {
     context.consume(today.as_bytes());
     let digest = context.finalize();
     let num = u32::from_be_bytes(digest.0[0..4].try_into().unwrap());
-    (num as usize) % count
+    (num % count as u32) as usize
+}
+
+/// Determine if we should use color based on the argument and environment
+fn is_color_enabled(color_arg: &ColorMode) -> bool {
+    use std::io::IsTerminal;
+
+    let no_color = std::env::var_os("NO_COLOR").is_some();
+    let is_tty = std::io::stdout().is_terminal();
+    match color_arg {
+        ColorMode::Auto => is_tty && !no_color,
+        ColorMode::Always => true,
+        ColorMode::Never => false,
+    }
 }
 
 /// Show fortune message for engineers
 fn main() {
     let args = Args::parse();
 
-    let byte_cookies = if let Some(file_path) = args.json {
+    let cookies = if let Some(file_path) = args.json {
         get_cookies_from_file(&file_path)
     } else {
         get_embedded_cookies()
     };
 
-    let index = if let Some(user) = args.user {
+    let cookie_index = if let Some(user) = args.user {
         let today = chrono::Local::now().format("%Y-%m-%d").to_string();
-        decide_todays_index(byte_cookies.len(), &today, &user)
+        decide_todays_index(cookies.len(), &today, &user)
     } else {
-        decide_random_index(byte_cookies.len())
+        decide_random_index(cookies.len())
     };
 
-    let cookie = &byte_cookies[index];
-    println!("{}", cookie.snippet);
-    println!("{}", cookie.message);
+    let cookie = &cookies[cookie_index];
+
+    let (cyan, yellow, reset) = if is_color_enabled(&args.color) {
+        ("\x1b[36m", "\x1b[33m", "\x1b[0m")
+    } else {
+        ("", "", "")
+    };
+    println!("{}{}{}", cyan, cookie.snippet, reset);
+    println!("{}{}{}", yellow, cookie.message, reset);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,15 +63,20 @@ fn decide_random_index(count: usize) -> usize {
     rand::Rng::random_range(&mut rng, 0..count)
 }
 
-/// Decide message index from today's date and user name
+/// Decide a message index from today's date and username
 fn decide_todays_index(count: usize, today: &str, user: &str) -> usize {
+    assert!(count > 0);
+
     let mut context = md5::Context::new();
     context.consume(user.as_bytes());
     context.consume(b":");
     context.consume(today.as_bytes());
+
     let digest = context.finalize();
     let num = u32::from_be_bytes(digest.0[0..4].try_into().unwrap());
-    (num % count as u32) as usize
+
+    let count = u32::try_from(count).unwrap();
+    (num % count) as usize
 }
 
 /// Determine if we should use color based on the argument and environment


### PR DESCRIPTION
This pull request updates both the user documentation and the codebase for the `bytecookie` project, focusing on improved color output support, enhancements to the command-line interface, and refinements to the fortune messages. The most important changes are grouped below.

**Feature: Colorized Output and CLI Improvements**

* Added a `--color`/`-c` command-line option to control colored output (`auto`, `always`, `never`), implemented via the new `ColorMode` enum in `src/main.rs`. The output color is now determined by this argument and the `NO_COLOR` environment variable. [[1]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL1-R11) [[2]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR23-R26) [[3]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL62-R115)
* Updated the documentation in `README.md` to describe the new color option and the `NO_COLOR` environment variable, clarifying the purpose and usage of the tool and its options.
* Added `NO_COLOR` to the environment variables section in the documentation, explaining its effect on output.

**Enhancement: Message Content and Formatting**

* Revised and improved several fortune messages in `assets/bytecookies.json` for clarity, conciseness, and tone. Added new messages for common programming warnings and merge conflicts, and standardized error snippet formatting (e.g., `"EPERM (errno 1): Operation not permitted"`). [[1]](diffhunk://#diff-52e3a978acdf6eaca1495d11f9eb0e70ada763f5bb26cd5834850e546907dcb3L12-R12) [[2]](diffhunk://#diff-52e3a978acdf6eaca1495d11f9eb0e70ada763f5bb26cd5834850e546907dcb3L36-R64) [[3]](diffhunk://#diff-52e3a978acdf6eaca1495d11f9eb0e70ada763f5bb26cd5834850e546907dcb3L88-R88) [[4]](diffhunk://#diff-52e3a978acdf6eaca1495d11f9eb0e70ada763f5bb26cd5834850e546907dcb3L140-R140) [[5]](diffhunk://#diff-52e3a978acdf6eaca1495d11f9eb0e70ada763f5bb26cd5834850e546907dcb3L172-R172) [[6]](diffhunk://#diff-52e3a978acdf6eaca1495d11f9eb0e70ada763f5bb26cd5834850e546907dcb3R194-R197) [[7]](diffhunk://#diff-52e3a978acdf6eaca1495d11f9eb0e70ada763f5bb26cd5834850e546907dcb3R206-R209) [[8]](diffhunk://#diff-52e3a978acdf6eaca1495d11f9eb0e70ada763f5bb26cd5834850e546907dcb3L228-R240) [[9]](diffhunk://#diff-52e3a978acdf6eaca1495d11f9eb0e70ada763f5bb26cd5834850e546907dcb3L247-R299)

**Documentation Cleanup**

* Removed the redundant "FILE" section from the `README.md` to streamline documentation and avoid confusion.